### PR TITLE
[python3.8+] Update ecc.py to use time.perf_counter

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,56 @@
+# Copilot Instructions for Simchain
+
+## 项目架构概览
+- Simchain 是一个用于教学和研究的区块链模拟器，核心目录为 `simchain/`。
+- 主要模块：
+  - `network.py`：区块链网络与节点管理，入口类为 `Network`。
+  - `peer.py`：节点（Peer）实现，包含钱包、交易、区块链等。
+  - `wallet.py`、`ecc.py`：钱包与密钥管理，支持 ECDSA。
+  - `merkletree.py`：Merkle 树结构与验证。
+  - `datatype.py`：核心数据类型（UTXO、Tx、Block 等）。
+  - `lbc/`：格密码相关实验性模块。
+  - 其他如 `base58.py`、`mnemonics.py` 为编码和助记词工具。
+
+## 关键开发流程
+- 构建/安装：
+  - 推荐 `pip install simchain` 或 `python setup.py install`。
+- 交互式用法：
+  - 通过 `Network` 类创建区块链网络，模拟节点、交易、共识。
+  - 示例：
+    ```python
+    from simchain import Network
+    net = Network()
+    net.peers[0].create_transaction(net.peers[1].addr, 100)
+    net.consensus()
+    ```
+- 钱包与密钥：
+  - 每个 Peer 拥有 Wallet，密钥对为 `SigningKey`/`VerifyingKey`，地址为 base58 编码。
+  - 钱包可动态生成密钥对，支持多地址。
+
+## 项目约定与模式
+- 数据流：所有交易、区块、UTXO 都通过 Peer 对象流转，区块链状态由 Network 管理。
+- 交易费用与奖励：每次交易会收取手续费，挖矿奖励由共识模块分配。
+- 新节点加入时自动同步区块链。
+- 代码风格：
+  - 数据类型与结构体定义集中在 `datatype.py`。
+  - 算法实现（如哈希、签名）分散在各自模块。
+  - 注释率较低，建议 AI 生成代码时补充 docstring。
+
+## 测试与调试
+- 主要通过交互式 Python shell 进行功能验证。
+- 没有标准化测试脚本，建议以 `README.md` 示例为基础编写测试。
+
+## 依赖与集成
+- 仅依赖 Python 标准库，无第三方区块链库。
+- 格密码相关实验性代码在 `lbc/`，与主链逻辑隔离。
+
+## 重要文件索引
+- `simchain/network.py`：主入口，区块链网络与共识
+- `simchain/peer.py`：节点与钱包
+- `simchain/datatype.py`：核心数据结构
+- `simchain/wallet.py`、`simchain/ecc.py`：密钥与签名
+- `simchain/merkletree.py`：Merkle 树
+- `simchain/lbc/`：格密码实验
+
+---
+如需补充说明或发现不清晰之处，请反馈具体模块或场景。

--- a/.github/workflows/qc.yml
+++ b/.github/workflows/qc.yml
@@ -1,0 +1,8 @@
+on: [push, pull_request, workflow_dispatch]
+jobs:
+  quality-check:
+    uses: ZhulongNT/fuck-u-code/.github/workflows/code-quality-analysis.yml@main
+    with:
+      language: 'en-US'
+      top-files: 10
+      artifact-name: 'code-quality-report'

--- a/.github/workflows/qc.yml
+++ b/.github/workflows/qc.yml
@@ -3,6 +3,6 @@ jobs:
   quality-check:
     uses: ZhulongNT/fuck-u-code/.github/workflows/code-quality-analysis.yml@main
     with:
-      language: 'en-US'
+      language: 'zh-CN'
       top-files: 10
       artifact-name: 'code-quality-report'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,8 @@
+name: CI
+on: [workflow_dispatch]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Hello World"

--- a/README.md
+++ b/README.md
@@ -3,39 +3,43 @@ Simchain
 
 Simchain is a blockchain simulator for education and research purpose by Dr.Pei at the sponsor of Hubei University of technology.
 
-
-
 Version
-=======
+------
+
 Current:1.0.0
 
 Requirements
-=======
+------
+
 Python 3
 
 Installation
-=======
+------
+
 $ pip install simchain
 
 Or
 
 $ python setup.py install
 
-
 Usage
-========
+------
+
 * Education. Like a bitcoin simulator,the users can directly understand the data flowing for peers to peers.
 * Research. Reseachers can use it for algrithms testing. It will be also used as a network delay and pressure testing tools in the future.
 
 Algorithm
-========
+------
+
 * Hash function: double sha256 algorithm
 * DSA: ECDSA
 * Lattice-based cryptography is discussed
 
 Data type defination
-========
+------
+
 Simchain is more likely a bitcoin simulator by far, so the user-defined data types are similar with bitcoin.
+
 * Pointer ---A pointer to a transaction unspent output
 * Vin    --- value input unit
 * Vout   --- value output unit
@@ -47,18 +51,18 @@ Simchain is more likely a bitcoin simulator by far, so the user-defined data typ
 * VerifyingKey ----- publick key
 * Wallet ----- wallet
 
-
 Code example
-========
+------
 
-1 General 
--------
+1 General
+
 ```python
    >>> from simchain import Network
    >>> net = Network()
 ```
--------
+
 The code above created a blockchain network. The default peers number is 12 and every peer obtain equal money 100000 fen (yuan,jiao,fen) at the very begining.We can check the peers number and balance as follows.
+
 ```python
    >>> net.nop
    12
@@ -67,8 +71,10 @@ The code above created a blockchain network. The default peers number is 12 and 
    >>> net.peers[0].get_balance()
    >>> 100000
 ```
+
 ------
 Now,we can let the peers make transactions each other like this.
+
 ```python
    >>> satoshi = net.peers[0]
    >>> john = net.peers[4]
@@ -79,16 +85,20 @@ Now,we can let the peers make transactions each other like this.
    >>> satoshi.create_transaction(john.addr,100)
    >>> satoshi.broadcast_transaction()
 ```
+
 ------
 We named two peers satoshi and john respectively. They both got 10000 fen and one UTXO at the beggining. Let satoshi create a transaction which sends 100 fen to john and broadcast it. 'addr' means address same as in bitcoin.
+
 ```python
    >>> satoshi.get_balance()
    99890
    >>> john.get_balance()
    100100
 ```
+
 ------
 It seems that the transaction succeeded. However, why 99890 not 99900? where is the lost 10 fen?
+
 ```python
    >>> satoshi.get_utxo()
    [UTXO(vout:Vout(to_addr:1BwmfFdQwnAz78PcdrzSgBUpRYZbbMSY7L,value:99890),pointer:Pointer(tx_id:d7208876508ddeca918bdf930cc6d35eaf859487fec5d5d0146305dd5ac1950c,n:1))]
@@ -100,8 +110,10 @@ It seems that the transaction succeeded. However, why 99890 not 99900? where is 
    >>> john.get_unconfirmed_utxo()
    [UTXO(vout:Vout(to_addr:1KP1TUiWJStHmUwgvZQmgd3GwDtExr3kFH,value:100),pointer:Pointer(tx_id:d7208876508ddeca918bdf930cc6d35eaf859487fec5d5d0146305dd5ac1950c,n:0))]
 ```
+
 ------
-We found satoshi got only one UTXO with 99890 fen, but unconfirmed. john had two UTXOs, 10000 fen and 100 fen (unconfirmed) respectively. The unconfirmed 100 fen UTXO came from satoshi. Why was that? Where is the lost 10 fen? 
+We found satoshi got only one UTXO with 99890 fen, but unconfirmed. john had two UTXOs, 10000 fen and 100 fen (unconfirmed) respectively. The unconfirmed 100 fen UTXO came from satoshi. Why was that? Where is the lost 10 fen?
+
 ```python
    >>> net.consensus()
    2018-11-13 16:16:28,002 - 7 peers are mining
@@ -119,14 +131,18 @@ We found satoshi got only one UTXO with 99890 fen, but unconfirmed. john had two
    >>> ben.get_balance()
    100510
 ```
+
 ------
 After the consensus reached, we found both satoshi and john had uncomfirmed UTXO no more.The mining winner --ben (pid = 10) got 510 fen increased,500 mining reward and 10 transaction fee (The lost 10 fen). The transaction finished untill the consensus reached.
+
 ```python
    >>> net.make_random_transactions()
    >>> net.consensus()
 ```
+
 ------
 We can also use two lines above to make random transactions and reach one consensus.
+
 ```python
    >>> alice = net.peers[-1]
    >>> alice.get_balance()
@@ -138,12 +154,14 @@ We can also use two lines above to make random transactions and reach one consen
    >>> len(alice.blockchain)
    3
 ```
+
 ------
 We can also add new user (peer) into the network. However, the newer(alice) got no money.Satoshi and john got money since the system gave them money in  the genesis block at the begining. alice had the same blockchain as satoshi had because when a new peer joins in the system, it has to update the blockchain according to the old full peer.Meanwhile, the blockchain increased to 3 since two consensuses reached by far.
 
------
+------
+
 2 Wallet and keys
------
+
 ```python
    >>> satoshi.wallet.keys
    [keys pair]
@@ -162,8 +180,10 @@ We can also add new user (peer) into the network. However, the newer(alice) got 
    >>> satoshi.wallet.addrs[0]
    '1DnxfAWqMPW2nvQug2x2ocPvrM7Fjf2g55'
 ```
------
-Every peer has a Wallet attribute.Wallet consists of key pair (SigningKey and VerifyingKey object) and adrress list. 
+
+------
+Every peer has a Wallet attribute.Wallet consists of key pair (SigningKey and VerifyingKey object) and adrress list.
+
 ```python
    >>> len(satoshi.wallet.keys)
    1
@@ -173,4 +193,3 @@ Every peer has a Wallet attribute.Wallet consists of key pair (SigningKey and Ve
    >>> len(satoshi.wallet.addrs)
    2
 ```
------

--- a/simchain/ecc.py
+++ b/simchain/ecc.py
@@ -554,13 +554,15 @@ def verify(sig,G,K,message):
 
 #######Try all possibilities
 
-from time import clock
+# from time import clock
+# DEPRECIATED since python 3.8
+from time import perf_counter
 from math import sqrt,ceil
 def crack_by_brute_force(G,K):
-    start_time = clock()
+    start_time = perf_counter()
     for k in range(G.order):
         if k*G == K:
-            end_time = clock()
+            end_time = perf_counter()
             print ("Priv key: k = " + str(k))
             print ("Time: " + str(round(end_time - start_time, 3)) + " secs")
             

--- a/simchain/hdwallet.py
+++ b/simchain/hdwallet.py
@@ -101,6 +101,11 @@ class Keys:
         assert(0 <= i < MAX_CHILD_NUM)
         assert(self.__depth < 0xff)
 
+        """
+        派生子钱包。
+        :param index: 子钱包索引。
+        :return: 子钱包对象。
+        """
         len_i = orderlen(MAX_CHILD_NUM)
         str_i = number_to_bytes(i,len_i)
 

--- a/simchain/merkletree.py
+++ b/simchain/merkletree.py
@@ -1,13 +1,20 @@
-
 from .ecc import sha256d
-class Node(object):
 
+class Node(object):
+    """
+    Merkle tree node. Holds value, child/parent pointers, and sibling info.
+    """
     def __init__(self, data, prehashed=False):
+        """
+        Initialize a node.
+        Args:
+            data: bytes, raw or hashed value
+            prehashed: bool, if True, data is already hashed
+        """
         if prehashed:
             self.val = data
         else:
             self.val = sha256d(data)
-            
         self.left_child = None
         self.right_child = None
         self.parent = None
@@ -15,44 +22,72 @@ class Node(object):
         self.side = None
 
     def __repr__(self):
+        """
+        String representation for debugging.
+        """
         return "MerkleTreeNode('{0}')".format(self.val)
 
-
-
 class MerkleTree(object):
-
+    """
+    Merkle tree structure. Supports root calculation and path generation.
+    """
     def __init__(self,leaves = []):
+        """
+        Initialize MerkleTree.
+        Args:
+            leaves: list of bytes, already hashed
+        """
         self.leaves = [Node(leaf,True) for leaf in leaves]
         self.root = None
 
     def add_node(self,leaf):
+        """
+        Add a new leaf node (raw data).
+        Args:
+            leaf: bytes
+        """
         self.leaves.append(Node(leaf))
 
-
     def clear(self):
+        """
+        Clear tree structure, keep leaves only.
+        """
         self.root = None
         for leaf in self.leaves:
             leaf.parent,leaf.bro,leaf.side = (None,)*3
 
-
     def get_root(self):
+        """
+        Calculate and return Merkle tree root hash.
+        Returns:
+            bytes: root hash
+        """
         if not self.leaves:
             return None
-
         level = self.leaves[::]
+        # Merge up until only one root node remains
         while len(level) != 1:
             level = self._build_new_level(level)
         self.root = level[0]
         return self.root.val
-        
+
     def _build_new_level(self, leaves):
+        """
+        Build parent level from current leaves.
+        Args:
+            leaves: list of Node
+        Returns:
+            list of Node
+        """
         new, odd = [], None
         if len(leaves) % 2 == 1:
+            # Odd number, last node promoted
             odd = leaves.pop(-1)
         for i in range(0, len(leaves), 2):
+            # Merge left and right node, create parent
             newnode = Node(leaves[i].val + leaves[i + 1].val)
-            newnode.lelf_child, newnode.right_child = leaves[i], leaves[i + 1]
-            leaves[i].side, leaves[i + 1].side,  = 'LEFT', 'RIGHT'
+            newnode.left_child, newnode.right_child = leaves[i], leaves[i + 1]  # fix typo
+            leaves[i].side, leaves[i + 1].side = 'LEFT', 'RIGHT'
             leaves[i].parent, leaves[i + 1].parent = newnode, newnode
             leaves[i].bro, leaves[i + 1].bro = leaves[i + 1], leaves[i]
             new.append(newnode)
@@ -61,6 +96,13 @@ class MerkleTree(object):
         return new
 
     def get_path(self, index):
+        """
+        Get path from leaf to root for proof.
+        Args:
+            index: int, leaf index
+        Returns:
+            list of (hash, side)
+        """
         path = []
         this = self.leaves[index]
         path.append((this.val, 'SELF'))
@@ -70,5 +112,5 @@ class MerkleTree(object):
         path.append((this.val, 'ROOT'))
         return path
 
-    
+
 

--- a/simchain/mnemonics.py
+++ b/simchain/mnemonics.py
@@ -3,6 +3,10 @@
 # Electrum - lightweight Bitcoin client
 # Copyright (C) 2011 thomasv@gitorious
 #
+"""
+mnemonics.py
+助记词相关实现。
+"""
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or

--- a/simchain/wallet.py
+++ b/simchain/wallet.py
@@ -20,6 +20,10 @@ class Keys(tuple):
     def pk(self):
         return self[1]
     
+    """
+    wallet.py
+    钱包相关实现。
+    """
     def __repr__(self):
         return "keys pair"
     


### PR DESCRIPTION
`clock` 方法在 Python 3.8 及更高版本中已被移除。如果您在代码中使用了 `clock`，需要将其替换为其他方法，例如 `perf_counter` 或 `process_time`，具体取决于您的需求。